### PR TITLE
Improve docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If everything is ok then you will be able to interact with web interface of API.
 ### Rest API
 If you want access API directly, for example through the `curl` tool, then you need to provide your Github basic token with every request.
 If you don't have one then you can get it here https://github.com/settings/tokens/new. After that you can use API like this:
-`curl -u {put your Github token here, remove curly braces}:x-oauth-basic -H "Content-Type: application/json" -k -X POST -d '{"task":"dummy:my_sleep"}' https://api.pulsar.local:8001/example/production`
+`curl -u {github-token}:x-oauth-basic -H "Content-Type: application/json" -X POST -d '{"task":"dummy:my_sleep"}' https://api.pulsar.local:8001/example/production`
 
 ### Websocket
 When socket client gets connected it needs to send authentication information as its first message. There are two options available:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ instance won't start. There are no options that have default value. All values s
   - `repo`. optional. Pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
   - `branch`. optional. Branch for pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
 - `auth`. optional. Authentication. Only if presented it should have its required options to be filled, otherwise no need to fill `auth.githubOauthId` and etc.
-  - `githubOauthId`. required. Github OAuth Application ID. To get it go to https://github.com/settings/applications/new
-  - `githubOauthSecret`. required. Github OAuth Application Secret. To get it go to https://github.com/settings/applications/new
+  - `githubOauthId`. required. Github OAuth Application ID.
+  - `githubOauthSecret`. required. Github OAuth Application Secret.
   - `githubOrg`. required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
   - `baseUrl`. required. URL where the pulsar-rest-api instance would have its web interface.
   - `callbackUrl`. required. OAuth callback Url. Must be relative to the `baseUrl`.
@@ -52,6 +52,18 @@ instance won't start. There are no options that have default value. All values s
   - `cert`. required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.
   - `pfx`. required if `key` or `cert` options aren't presented. Ssl pfx file (key + cert). Overrides `key` and `cert` options.
   - `passphrase`. optional. File containing the ssl passphrase.
+
+##### Github OAuth App setup.
+  - Go to https://github.com/settings/applications/new.
+  - There are going to be the fields: `Application name`, `Homepage URL`, `Application description`, `Authorization callback URL`. Fill them up.
+    For example here is the values that I've used on my local setup:
+    - `Application name` = pulsar-rest-api
+    - `Homepage URL` = https://api.pulsar.local:8001. That value should be the same as `baseUrl` from the config.
+    - `Application description` = bla bla super cool
+    - `Authorization callback URL` = https://api.pulsar.local:8001
+  
+  The only important info here is that `Homepage URL` and `Authorization callback URL` should be the same. Don't forget it when you fill your app.
+  - Submit them and you will receive `Client ID` and `Client Secret`. They are `githubOauthId` and `githubOauthSecret` correspondingly. 
 
 #####Verify that mongodb is up and running
 The mongodb instance that you defined in your config should be up and running before you start the pulsar.

--- a/README.md
+++ b/README.md
@@ -31,28 +31,28 @@ The default config is [`config.yaml`](bin/config.yaml) and it can be found in `b
 
 Please read carefully through the format of the config below. The options that are marked as required must be present in your config otherwise the
 instance won't start. There are no options that have default value. All values should be clearly defined.
-```yaml
-port: # required. Port where server listens for requests.
-logPath: # required. A file path where to write logs. Includes filename of the log. Can be absolute or relative.
-mongodb:# mongoDB connection parameters
-  host: # required. hostname
-  port: # required. port
-  db: # required. database name. Now there is only one collection 'jobs' will be used.
-pulsar:
-  repo: # optional. Pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
-  branch: # optional. Branch for pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
-auth: # optional. Authentication. Only if presented it should have its required options to be filled, otherwise no need to fill `auth.githubOauthId` and etc.
-  githubOauthId: # required. Github OAuth Application ID. To get it go to https://github.com/settings/applications/new
-  githubOauthSecret: # required. Github OAuth Application Secret. To get it go to https://github.com/settings/applications/new
-  githubOrg: # required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
-  baseUrl: # required. URL where the pulsar-rest-api instance would have its web interface.
-  callbackUrl: # required. OAuth callback Url. Must be relative to the baseUrl.
-ssl: # required if `auth` block is presented else it's optional. Only if presented it should have its required options to be filled, otherwise no need to fill `ssl.key` and etc.
-  key: # required if `pfx` isn't presented. Ssl private key file. Combine with `cert` option.
-  cert: # required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.
-  pfx: # required if `key` or `cert` options aren't presented. Ssl pfx file (key + cert). Overrides `key` and `cert` options.
-  passphrase: # optional. File containing the ssl passphrase.
-```
+
+- `port`. required. Port where server listens for requests.
+- `logPath`. required. A file path where to write logs. Includes filename of the log. Can be absolute or relative.
+- `mongodb`. mongoDB connection parameters
+  - `host`. required. hostname
+  - `port`. required. port
+  - `db`. required. database name. Now there is only one collection 'jobs' will be used.
+- `pulsar`:
+  - `repo`. optional. Pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
+  - `branch`. optional. Branch for pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
+- `auth`. optional. Authentication. Only if presented it should have its required options to be filled, otherwise no need to fill `auth.githubOauthId` and etc.
+  - `githubOauthId`. required. Github OAuth Application ID. To get it go to https://github.com/settings/applications/new
+  - `githubOauthSecret`. required. Github OAuth Application Secret. To get it go to https://github.com/settings/applications/new
+  - `githubOrg`. required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
+  - `baseUrl`. required. URL where the pulsar-rest-api instance would have its web interface.
+  - `callbackUrl`. required. OAuth callback Url. Must be relative to the `baseUrl`.
+- `ssl`. required if `auth` block is presented else it's optional. Only if presented it should have its required options to be filled, otherwise no need to fill `ssl.key` and etc.
+  - `key`. required if `pfx` isn't presented. Ssl private key file. Combine with `cert` option.
+  - `cert`. required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.
+  - `pfx`. required if `key` or `cert` options aren't presented. Ssl pfx file (key + cert). Overrides `key` and `cert` options.
+  - `passphrase`. optional. File containing the ssl passphrase.
+
 #####Verify that mongodb is up and running
 The mongodb instance that you defined in your config should be up and running before you start the pulsar.
 

--- a/README.md
+++ b/README.md
@@ -32,25 +32,25 @@ The default config is [`config.yaml`](bin/config.yaml) and it can be found in `b
 Please read carefully through the format of the config below. The options that are marked as required must be present in your config otherwise the
 instance won't start. There are no options that have default value. All values should be clearly defined.
 
-- `port`. required. Port where server listens for requests.
-- `logPath`. required. A file path where to write logs. Includes filename of the log. Can be absolute or relative.
-- `mongodb`. mongoDB connection parameters
-  - `host`. required. hostname
-  - `port`. required. port
-  - `db`. required. database name. Now there is only one collection 'jobs' will be used.
+- `port`: required. Port where server listens for requests.
+- `logPath`: required. A file path where to write logs. Includes filename of the log. Can be absolute or relative.
+- `mongodb`: mongoDB connection parameters
+  - `host`: required. hostname
+  - `port`: required. port
+  - `db`: required. database name. Now there is only one collection 'jobs' will be used.
 - `pulsar`:
-  - `repo`. optional. Pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
-  - `branch`. optional. Branch for pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
-- `auth`. optional. Authentication. Only if presented it should have its required options to be filled, otherwise no need to fill `auth.githubOauthId` and etc.
-  - `githubOauthId`. required. Github OAuth Application ID.
-  - `githubOauthSecret`. required. Github OAuth Application Secret.
-  - `githubOrg`. required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
-  - `baseUrl`. required. URL where the pulsar-rest-api instance would have its web interface.
-- `ssl`. required if `auth` block is presented else it's optional. Only if presented it should have its required options to be filled, otherwise no need to fill `ssl.key` and etc.
-  - `key`. required if `pfx` isn't presented. Ssl private key file. Combine with `cert` option.
-  - `cert`. required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.
-  - `pfx`. required if `key` or `cert` options aren't presented. Ssl pfx file (key + cert). Overrides `key` and `cert` options.
-  - `passphrase`. optional. File containing the ssl passphrase.
+  - `repo`: optional. Pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
+  - `branch`: optional. Branch for pulsar configuration repository. If omitted then [pulsar rules](https://github.com/nebulab/pulsar#loading-the-repository) applied.
+- `auth`: optional. Authentication. Only if presented it should have its required options to be filled, otherwise no need to fill `auth.githubOauthId` and etc.
+  - `githubOauthId`: required. Github OAuth Application ID.
+  - `githubOauthSecret`: required. Github OAuth Application Secret.
+  - `githubOrg`: required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
+  - `baseUrl`: required. URL where the pulsar-rest-api instance would have its web interface.
+- `ssl`: required if `auth` block is presented else it's optional. Only if presented it should have its required options to be filled, otherwise no need to fill `ssl.key` and etc.
+  - `key`: required if `pfx` isn't presented. Ssl private key file. Combine with `cert` option.
+  - `cert`: required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.
+  - `pfx`: required if `key` or `cert` options aren't presented. Ssl pfx file (key + cert). Overrides `key` and `cert` options.
+  - `passphrase`: optional. File containing the ssl passphrase.
 
 ##### Github OAuth App setup.
   - Go to https://github.com/settings/applications/new.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,11 @@ instance won't start. There are no options that have default value. All values s
 
 ##### Github OAuth App setup.
   - Go to https://github.com/settings/applications/new.
-  - There are going to be the fields: `Application name`, `Homepage URL`, `Application description`, `Authorization callback URL`. Fill them up.
-    For example here is the values that I've used on my local setup:
+  - There are going to be the fields. Fill them up. For example here is the values that I've used on my local setup:
     - `Application name` = pulsar-rest-api
     - `Homepage URL` = https://api.pulsar.local:8001. That value should be the same as `baseUrl` from the config.
-    - `Application description` = bla bla super cool
-    - `Authorization callback URL` = https://api.pulsar.local:8001
-  
-  The only important info here is that `Homepage URL` and `Authorization callback URL` should be the same. Don't forget it when you fill your app.
+    - `Application description`. It's optional. You can leave it empty.
+    - `Authorization callback URL`. It's optional. You can leave it empty and it will be the same as `Homepage URL`.
   - Submit them and you will receive `Client ID` and `Client Secret`. They are `githubOauthId` and `githubOauthSecret` correspondingly. 
 
 #####Verify that mongodb is up and running

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ instance won't start. There are no options that have default value. All values s
   - `githubOauthSecret`. required. Github OAuth Application Secret.
   - `githubOrg`. required. Github organization. User needs to be member of that organization to get access to the interface of pulsar-rest-api.
   - `baseUrl`. required. URL where the pulsar-rest-api instance would have its web interface.
-  - `callbackUrl`. required. OAuth callback Url. Must be relative to the `baseUrl`.
 - `ssl`. required if `auth` block is presented else it's optional. Only if presented it should have its required options to be filled, otherwise no need to fill `ssl.key` and etc.
   - `key`. required if `pfx` isn't presented. Ssl private key file. Combine with `cert` option.
   - `cert`. required if `pfx` isn't presented. Ssl public certificate file. Combine with `key` option. Append CA-chain within this file.

--- a/lib/auth/github-helper.js
+++ b/lib/auth/github-helper.js
@@ -7,7 +7,7 @@ function GithubHelper(config, tokenContainer) {
   this._tokenContainer = tokenContainer;
   this.githubOrg = config.githubOrg;
   this.baseUrl = config.baseUrl;
-  this.callbackUrl = config.callbackUrl;
+  this.callbackUrl = '/';
 
   this._oauth = new githubOAuth({
     githubClient: config.githubOauthId,//process.env['GITHUB_CLIENT'],

--- a/lib/config.js
+++ b/lib/config.js
@@ -88,10 +88,6 @@ var validScheme = {
         baseUrl: {
           type: 'uri',
           required: true
-        },
-        callbackUrl: {
-          type: 'string',
-          required: true
         }
       }
     },


### PR DESCRIPTION
cc @tomaszdurka 

Some small suggestions for readme:
- Config code block: Links don't work because it's code block. Rather make it a list?
- Docu: Add steps on how to fill out "New Github Application" form
- Question: What needs to be filled in `auth.callbackUrl` (docu unclear)?
- CURL example: 
 - Don't use `-k` (which is to ignore SSL problems)
 - Shorten "put your Github token here, remove curly braces"? -> just `{github-token}`