### PR TITLE
Auth options without ssl should produce more of a warning not an error

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,12 +21,6 @@ Config.prototype.asHash = function() {
 
 var validator = new Validator();
 
-validator.attributes.validateSsl = function(config) {
-  if (config.auth && !config.ssl) {
-    return 'Ssl options are required';
-  }
-};
-
 validator.attributes.validateSslPfx = function(ssl) {
   if (ssl && (!ssl.key || !ssl.cert) && !ssl.pfx) {
     return 'Ssl options must contain pair of `key` and `cert` or `pfx`';
@@ -35,7 +29,6 @@ validator.attributes.validateSslPfx = function(ssl) {
 
 var validScheme = {
   type: 'object',
-  validateSsl: true,
   properties: {
     port: {
       type: 'number',


### PR DESCRIPTION
It's not possible to run app without ssl and with auth configured.