### PR TITLE
Add tasks without description to `getAvailableTasks` output.

### DIFF
--- a/lib/pulsar/index.js
+++ b/lib/pulsar/index.js
@@ -89,14 +89,14 @@ module.exports = (function() {
     var args = {
       app: app,
       env: env,
-      capistranoOptions: ['--tasks']
+      capistranoOptions: ['-v', '--tasks']
     };
     var job = this._createJob(args);
     job.on('close', function() {
       if (job.status != PulsarJob.STATUS.FINISHED) {
         return callback(new Error('Collecting of available tasks finished abnormally.\n' + job.output));
       }
-      var regex = /cap\s([^\s]+)\s+#\s+([^\s].+)\n/g;
+      var regex = /cap\s([^\s]+)\s+#\s(.*)\n/g;
       var match;
       var jobs = {};
       while (null !== (match = regex.exec(job.stdout))) {

--- a/test/pulsar.js
+++ b/test/pulsar.js
@@ -141,6 +141,9 @@ describe('tests of pulsar API', function() {
     this.pulsar.getAvailableTasks(jobArgs.app.example, jobArgs.env.production, function(err, tasks) {
       assert(!err);
       assert(tasks['shell'], 'Shell task must be always present in available tasks');
+      _.each(jobArgs.task, function(taskName) {
+        assert(taskName in tasks, 'Test tasks must be present in available tasks');
+      });
       done();
     });
   });


### PR DESCRIPTION
@njam suggested a good idea to return also tasks that do not have descriptions.
For example now `getAvailableTasks` returns only:

```
cap invoke                    # Invoke a single command on the remote servers.
cap shell                     # Begin an interactive Capistrano session.
```

After including of description-less tasks it will be (for the test app/env):
```
cap deploy                    # 
cap deploy:pending            # 
cap deploy:show_next_revision # 
cap dummy:my_sleep            # 
cap dummy:my_sleep_unkillable # 
cap invoke                    # Invoke a single command on the remote servers.
cap shell                     # Begin an interactive Capistrano session.
```
which is more appropriate I think.

@tomaszdurka please share your opinion.