### PR TITLE
Output formatting: Don't wrap lines

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -12,6 +12,7 @@ button {
 }
 
 .console {
+  overflow: auto;
   border-radius: 4px;
   font-family: Courier;
   color: #CCCCCC;

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -12,7 +12,8 @@ button {
 }
 
 .console {
-  overflow: auto;
+  white-space: nowrap;
+  overflow-x: auto;
   border-radius: 4px;
   font-family: Courier;
   color: #CCCCCC;


### PR DESCRIPTION
@tomaszdurka @vogdb 
For better readability how about letting the output panel scroll in the x-direction instead of wrapping lines?
