### PR TITLE
Introduce "controlled shutdown" functionality

### DIFF
--- a/lib/pulsar/index.js
+++ b/lib/pulsar/index.js
@@ -18,6 +18,7 @@ module.exports = (function() {
     this.db = db;
     this.config = config || {};
     this.jobQueue = {};
+    this._isShuttingDown = false;
 
     events.EventEmitter.call(this);
     this._enableGracefulShutdown();
@@ -115,6 +116,13 @@ module.exports = (function() {
   };
 
   /**
+   * @returns {boolean}
+   */
+  Pulsar.prototype.isShuttingDown = function() {
+    return this._isShuttingDown;
+  };
+
+  /**
    * @param {Object} args {@see PulsarExec}
    * @param {Object} [data] {@see PulsarExec}
    * @return {PulsarJob} job
@@ -199,7 +207,8 @@ module.exports = (function() {
   };
 
   Pulsar.prototype._shutdown = function(signal) {
-    getLog().info('The process was interrupted by ' + signal + '. Killing all the current jobs.');
+    this._isShuttingDown = true;
+    getLog().info('The process was interrupted by ' + signal + '. Shutting down.');
     async.each(_.values(this.jobQueue), function(job, callback) {
       job.on('close', function() {
         callback();
@@ -207,9 +216,6 @@ module.exports = (function() {
     }, function() {
       process.exit();
     });
-    _.each(this.jobQueue, function(job) {
-      job.kill();
-    })
   };
 
   return Pulsar;

--- a/lib/pulsar/rest.js
+++ b/lib/pulsar/rest.js
@@ -17,6 +17,14 @@ module.exports = (function() {
   PulsarREST.prototype.installHandlers = function(server) {
     var self = this;
 
+    server.all('*', function(req, res, next) {
+      if (!self.pulsar.isShuttingDown()) {
+        return next();
+      } else {
+        return next(new PulsarError('Server is shutting down', 500));
+      }
+    });
+
     server.post('/:app/:env', function createJob(req, res, next) {
       var params = _.extend({}, req.params, req.body);
       var wait = !!params.wait;

--- a/test/spec/pulsar.js
+++ b/test/spec/pulsar.js
@@ -196,6 +196,7 @@ describe('tests of pulsar API', function() {
   });
 
   it('check if the current jobs are shutdowned when the api process is killed', function(done) {
+    this.timeout(12000);
     var self = this;
     async.map([null, null], function(dummy, callback) {
       self.pulsar.createJob(
@@ -214,7 +215,7 @@ describe('tests of pulsar API', function() {
       assert(jobs && jobs.length === 2);
       process.on('exit', function() {
         _.each(jobs, function(job) {
-          assert(job.status == PulsarJob.STATUS.KILLED, 'Job should be killed');
+          assert(job.status == PulsarJob.STATUS.FINISHED, 'Job should be finished');
         });
         //because `_shutdown` kills the process, we need to clean after the test manually.
         self.pulsarDb.collection.remove(done);


### PR DESCRIPTION
When the server receives a `SIGTERM` we should initiate a *controlled shutdown sequence* to avoid any running tasks to be interrupted:
1. Set "shutdown" flag on the server
2. Don't accept any new tasks any more
3. Exit normally once all running tasks ended

@tomaszdurka @vogdb thought?